### PR TITLE
fix err of go build

### DIFF
--- a/pkg/adapter/zookeeper/registry_client.go
+++ b/pkg/adapter/zookeeper/registry_client.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/mesh-operator/pkg/adapter/constant"
 	"github.com/mesh-operator/pkg/adapter/events"
 	"github.com/samuel/go-zookeeper/zk"
 )


### PR DESCRIPTION
fix the err when build
```
go build
# github.com/mesh-operator/pkg/adapter/zookeeper
../../pkg/adapter/zookeeper/registry_client.go:125:22: undefined: constant
```